### PR TITLE
levenshtein-distance was broken due to improper checking for empty collections in maz-or-zero

### DIFF
--- a/src/clj/clj_diff/core.clj
+++ b/src/clj/clj_diff/core.clj
@@ -70,7 +70,8 @@
         (reduce + (map #(count (drop 1 %)) (:+ edit-script))))))
 
 (defn- max-or-zero [coll]
-  (if (seq coll)
+  (if (and (coll? coll)
+           (not (empty? coll)))
     (apply max coll)
     0))
 

--- a/test/clj_diff/test/core.clj
+++ b/test/clj_diff/test/core.clj
@@ -58,7 +58,7 @@
           {:+ [[0 \9 \2 \5]
                [1 \C]
                [9 \c \Y \h \T \5 \h]
-               [15 \L] 
+               [15 \L]
                [17 \T \3]
                [28 \2 \T \5 \C \7 \U]
                [29 \L \z \5 \v]]
@@ -68,7 +68,7 @@
 (deftest roundtrip
   (are [a b]
        (= b (patch a (diff a b)))
-       
+
        "aba" "aca"
        "abcabba" "cbabac"
        "FWdRgevf43" "T5C7U3Lz5v"
@@ -98,7 +98,8 @@
        "kitten" "sitting" 3
        "Saturday" "Sunday" 3
        "gumbo" "gambol" 2
-       "nBP8GaFHVls2dI8h9aK1FWdRgevf43" "925BCPcYhT5hs8L9T3K2T5C7U3Lz5v" 28))
+       "nBP8GaFHVls2dI8h9aK1FWdRgevf43" "925BCPcYhT5hs8L9T3K2T5C7U3Lz5v" 28
+       [1 2 4] [1 2 4 3] 1))
 
 (deftest longest-common-subseq-test
   (are [a b _ d] (= (longest-common-subseq a b) d)


### PR DESCRIPTION
Now all but one of the tests pass. I didn't dig deeper, what should be the correct answer in that failing one: 30 or 28...
