### PR TITLE
Replace nil with explicit sentinel for diff and patch

### DIFF
--- a/src/clj/clj_diff/core.clj
+++ b/src/clj/clj_diff/core.clj
@@ -41,7 +41,7 @@
 
 (defn patch*
   [s edit-script]
-  (filter #(not (nil? %)) (merge-patch s edit-script nil)))
+  (filter #(not (= ::delete-sentinel %)) (merge-patch s edit-script ::delete-sentinel)))
 
 (defmulti ^{:arglists '([s edit-script])} patch
   "Use the instructions in the edit script to transform the sequence s into

--- a/src/clj/clj_diff/miller.clj
+++ b/src/clj/clj_diff/miller.clj
@@ -145,7 +145,7 @@
   (let [d (edit-dist delta p k)
         head-x (backtrack-snake a b x (- x k))]
     (loop [head-x head-x]
-      (let [move (first (filter #(and (not (nil? %)) ;; <<<===
+      (let [move (first (filter #(and (not (= ::sentinel %)) ;; <<<===
                                       (= (:d %) (dec d)))
                                 (map #(% graph delta p head-x k)
                                      [look-left look-up])))]
@@ -195,7 +195,7 @@
           edits))
 
 (defn vectorize [& more]
-  (map #(vec (cons nil %)) more))
+  (map #(vec (cons ::sentinel %)) more))
 
 (defn order->ses
   [a b]

--- a/test/clj_diff/test/core.clj
+++ b/test/clj_diff/test/core.clj
@@ -6,6 +6,12 @@
   (let [t (fn [a b] (edit-distance (diff a b)))]
     (is (= (t [1 2 3 4 3 2 3 2 1 2 3] [2 3 1 2 3 4 5 4 3])
            10))
+    (is (= (t [nil 1 2] [1 2])
+           1))
+    (is (= (t [1 2] [nil 1 2])
+           1))
+    (is (= (t [nil 1 2] [nil 1 2])
+           0))
     (is (= (t "abcab" "cbab")
            3))
     (is (= (t "abcabba" "cbabac")
@@ -69,6 +75,8 @@
   (are [a b]
        (= b (patch a (diff a b)))
 
+       [nil 42] [42]
+       [42] [42 nil]
        "aba" "aca"
        "abcabba" "cbabac"
        "FWdRgevf43" "T5C7U3Lz5v"


### PR DESCRIPTION
Nil is a valid value in a sequence, but was used as an iterator marker, causing program to hang.
Similarly, patch used nil as a deletion-marker.

This commit replaces both nil uses with explicit sentinel values.